### PR TITLE
Add `pyproject.toml` to declare numpy dependency in setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+        "setuptools>=42.0.0",
+        "wheel>=0.34.2",
+        # setup.py uses numpy.distutils, which was removed in 1.23
+        "numpy<1.23",
+        ]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This allows, for example, `uv` to reason about the package and extract its metadata without dying.